### PR TITLE
Change that fixes memory consumption in Nim, plus some style fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ leverages CGroup capabilities to capture the high-water RSS+CACHE memory usage.
 | Kotlin JVM (no-limit / -Xm*50M)   | 0.53 / 0.51        | x2.4          | 144 / 30   | x379 / x79        | N/A                               | Kotlinc 1.2.40 + OpenJDK 1.8.0   |
 | Kotlin Native                     | 5.88               | x26.7         | 1.2        | x3.2              | 0.239                             | Kotlinc-native 0.7               |
 | Swift                             | 2.04               | x9.3          | 2.5        | x6.6              | 0.020 + Swift shared libraries    | Swift 4.1                        |
-| Nim                               | 0.95               | x4.3          | 0.5        | x1.3              | 0.63                              | Nim 0.18 / GCC 8.1.0             |
-| Nim (gc:markAndSweep)             | 0.55               | x2.5          | 5          | x13               | 0.111                             | Nim 0.18 / GCC 8.1.0             |
+| Nim                               | (needs update)               | ...          | ...        | ...              | ...                              | Nim 0.18 / GCC 8.1.0             |
+| Nim (gc:markAndSweep)             | (needs update)               | ...          | ...          | ...               | ...                             | Nim 0.18 / GCC 8.1.0             |
 | Python (CPython)                  | 12.25              | x55.7         | 5          | x13               | N/A                               | CPython 3.6                      |
 | Python (PyPy)                     | 3.20               | x14.5         | 48.5       | x128              | N/A                               | PyPy 6.0.0                       |
 

--- a/nim/main.nim
+++ b/nim/main.nim
@@ -1,95 +1,95 @@
 import random
 
 type Node = ref object
-    x: int
-    y: int
-    left: Node
-    right: Node
+  x: int
+  y: int
+  left: Node
+  right: Node
 
 proc new_node(x: int): Node =
-    return Node(x: x, y: rand(2147483647), left: nil, right: nil)
+  return Node(x: x, y: rand(2147483647), left: nil, right: nil)
 
 proc merge(lower: Node, greater: Node): Node =
-    if lower == nil:
-        return greater
-    
-    if greater == nil:
-        return lower
-    
-    if lower.y < greater.y:
-        lower.right = merge(lower.right, greater)
-        return lower
-    else:
-        greater.left = merge(lower, greater.left)
-        return greater
+  if lower == nil:
+    return greater
+
+  if greater == nil:
+    return lower
+
+  if lower.y < greater.y:
+    lower.right = merge(lower.right, greater)
+    return lower
+  else:
+    greater.left = merge(lower, greater.left)
+    return greater
 
 proc splitBinary(orig: Node, value: int): (Node, Node) =
-    if orig == nil:
-        return (nil, nil)
-    
-    if orig.x < value:
-        let splitPair = splitBinary(orig.right, value)
-        orig.right = splitPair[0]
-        return (orig, splitPair[1])
-    else:
-        let splitPair = splitBinary(orig.left, value)
-        orig.left = splitPair[1]
-        return (splitPair[0], orig)
+  if orig == nil:
+    return (nil, nil)
+
+  if orig.x < value:
+    let splitPair = splitBinary(orig.right, value)
+    orig.right = splitPair[0]
+    return (orig, splitPair[1])
+  else:
+    let splitPair = splitBinary(orig.left, value)
+    orig.left = splitPair[1]
+    return (splitPair[0], orig)
 
 proc merge3(lower: Node, equal: Node, greater: Node): Node =
-    return merge(merge(lower, equal), greater)
+  return merge(merge(lower, equal), greater)
 
 
 type SplitResult = object
-    lower: Node
-    equal: Node
-    greater: Node
+  lower: Node
+  equal: Node
+  greater: Node
 
 
 proc split(orig: Node, value: int): SplitResult =
-    let (lower, equalGreater) = splitBinary(orig, value)
-    let (equal, greater) = splitBinary(equalGreater, value + 1)
-    return SplitResult(lower: lower, equal: equal, greater: greater)
+  let (lower, equalGreater) = splitBinary(orig, value)
+  let (equal, greater) = splitBinary(equalGreater, value + 1)
+  return SplitResult(lower: lower, equal: equal, greater: greater)
 
 
 type Tree = ref object
-    root: Node
+  root: Node
 
 proc has_value(self: Tree, x: int): bool =
-    let splited = split(self.root, x)
-    let res = splited.equal != nil
-    self.root = merge3(splited.lower, splited.equal, splited.greater)
-    return res
+  let splited = split(self.root, x)
+  let res = splited.equal != nil
+  self.root = merge3(splited.lower, splited.equal, splited.greater)
+  return res
 
 proc insert(self: Tree, x: int) =
-    var splited = split(self.root, x)
-    if splited.equal == nil:
-        splited.equal = new_node(x)
-    self.root = merge3(splited.lower, splited.equal, splited.greater)
+  var splited = split(self.root, x)
+  if splited.equal == nil:
+    splited.equal = new_node(x)
+  self.root = merge3(splited.lower, splited.equal, splited.greater)
 
 proc erase(self: Tree, x: int) =
-    let splited = split(self.root, x)
-    self.root = merge(splited.lower, splited.greater)
+  let splited = split(self.root, x)
+  self.root = merge(splited.lower, splited.greater)
 
 proc main() =
-    let tree = Tree()
-    var cur = 5
-    var res = 0
+  let tree = Tree()
+  var cur = 5
+  var res = 0
 
-    for i in countup(1, 1000000):
-        let a = cur mod 3
-        cur = (cur * 57 + 43) mod 10007
-        case a:
-        of 0:
-            tree.insert(cur)
-        of 1:
-            tree.erase(cur)
-        of 2:
-            if tree.has_value(cur):
-                res += 1
-        else:
-          continue
-    echo res
+  for i in countup(1, 1000000):
+    let a = cur mod 3
+    cur = (cur * 57 + 43) mod 10007
+    case a:
+    of 0:
+      tree.insert(cur)
+    of 1:
+      tree.erase(cur)
+    of 2:
+      if tree.has_value(cur):
+        res += 1
+    else:
+      continue
+  echo res
 
 when isMainModule:
-    main()
+  main()

--- a/nim/main.nim
+++ b/nim/main.nim
@@ -7,7 +7,7 @@ type Node = ref object
     right: Node
 
 proc new_node(x: int): Node =
-    return Node(x: x, y: random.random(2147483647), left: nil, right: nil)
+    return Node(x: x, y: rand(2147483647), left: nil, right: nil)
 
 proc merge(lower: Node, greater: Node): Node =
     if lower == nil:
@@ -40,7 +40,7 @@ proc merge3(lower: Node, equal: Node, greater: Node): Node =
     return merge(merge(lower, equal), greater)
 
 
-type SplitResult = ref object
+type SplitResult = object
     lower: Node
     equal: Node
     greater: Node
@@ -79,13 +79,16 @@ proc main() =
     for i in countup(1, 1000000):
         let a = cur mod 3
         cur = (cur * 57 + 43) mod 10007
-        if a == 0:
+        case a:
+        of 0:
             tree.insert(cur)
-        elif a == 1:
+        of 1:
             tree.erase(cur)
-        elif a == 2:
+        of 2:
             if tree.has_value(cur):
                 res += 1
+        else:
+          continue
     echo res
 
 when isMainModule:

--- a/nim/main.nim
+++ b/nim/main.nim
@@ -76,7 +76,7 @@ proc main() =
   var cur = 5
   var res = 0
 
-  for i in countup(1, 1000000):
+  for i in 1 ..< 1000000:
     let a = cur mod 3
     cur = (cur * 57 + 43) mod 10007
     case a:


### PR DESCRIPTION
As it says it the title, simple fix that makes the Nim with `--gc:markAndSweep` perform vastly better in terms of memory consumption. 