### PR TITLE
Speed-up Go version.

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -23,7 +23,7 @@ func NewNode(v int) *Node {
 }
 
 type Tree struct {
-	Root Node
+	Root *Node
 }
 
 func (t *Tree) HasValue(v int) bool {
@@ -36,7 +36,7 @@ func (t *Tree) HasValue(v int) bool {
 func (t *Tree) Insert(v int) error {
 	splitted := split(t.Root, v)
 	if !splitted.Equal.notEmpty {
-		splitted.Equal = *NewNode(v)
+		splitted.Equal = NewNode(v)
 	}
 	t.Root = merge3(splitted.Lower, splitted.Equal, splitted.Greater)
 	return nil
@@ -49,12 +49,12 @@ func (t *Tree) Erase(v int) error {
 }
 
 type SplitResult struct {
-	Lower   Node
-	Equal   Node
-	Greater Node
+	Lower   *Node
+	Equal   *Node
+	Greater *Node
 }
 
-func merge(lower, greater Node) Node {
+func merge(lower, greater *Node) *Node {
 	if !lower.notEmpty {
 		return greater
 	}
@@ -67,46 +67,46 @@ func merge(lower, greater Node) Node {
 		if lower.Right == nil {
 			lower.Right = &Node{}
 		}
-		right := merge(*lower.Right, greater)
-		lower.Right = &right
+		right := merge(lower.Right, greater)
+		lower.Right = right
 		return lower
 	}
 
 	if greater.Left == nil {
 		greater.Left = &Node{}
 	}
-	left := merge(lower, *greater.Left)
-	greater.Left = &left
+	left := merge(lower, greater.Left)
+	greater.Left = left
 	return greater
 }
 
-func merge3(lower, equal, greater Node) Node {
+func merge3(lower, equal, greater *Node) *Node {
 	return merge(merge(lower, equal), greater)
 }
 
-func splitBinary(original Node, value int) (Node, Node) {
-	if original == (Node{}) || !original.notEmpty {
-		return Node{}, Node{}
+func splitBinary(original *Node, value int) (*Node, *Node) {
+	if original == nil || *original == (Node{}) || !original.notEmpty {
+		return &Node{}, &Node{}
 	}
 
 	if original.X < value {
 		if original.Right == nil {
 			original.Right = &Node{}
 		}
-		splitPair0, splitPair1 := splitBinary(*original.Right, value)
-		original.Right = &splitPair0
+		splitPair0, splitPair1 := splitBinary(original.Right, value)
+		original.Right = splitPair0
 		return original, splitPair1
 	}
 
 	if original.Left == nil {
 		original.Left = &Node{}
 	}
-	splitPair0, splitPair1 := splitBinary(*original.Left, value)
-	original.Left = &splitPair1
+	splitPair0, splitPair1 := splitBinary(original.Left, value)
+	original.Left = splitPair1
 	return splitPair0, original
 }
 
-func split(original Node, value int) SplitResult {
+func split(original *Node, value int) SplitResult {
 	lower, equalGreater := splitBinary(original, value)
 	equal, greater := splitBinary(equalGreater, value+1)
 	return SplitResult{lower, equal, greater}


### PR DESCRIPTION
Use *Node instead of Node (same as D/C++).
This changes performance from:

real    0m3.840s
user    0m4.647s
sys     0m0.087s

to:

real    0m0.653s
user    0m0.709s
sys     0m0.014s

On my machine (core i7-6700).