### PR TITLE
Simplify C# version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,3 @@
 *.pyc
 nimcache
 rust/target
-c#/bin
-c#/obj

--- a/c#/.gitignore
+++ b/c#/.gitignore
@@ -1,0 +1,3 @@
+bin
+obj
+.vs

--- a/c#/Benchmark.csproj
+++ b/c#/Benchmark.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/c#/Benchmark.csproj
+++ b/c#/Benchmark.csproj
@@ -1,8 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
-
 </Project>

--- a/c#/Benchmark.csproj
+++ b/c#/Benchmark.csproj
@@ -2,5 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 </Project>

--- a/c#/Program.cs
+++ b/c#/Program.cs
@@ -1,30 +1,7 @@
 ﻿using System;
 
-namespace Benchmark
-{
-    class SplitResult {
-        public SplitResult(Node lower, Node equal, Node greater) {
-            this.lower = lower;
-            this.equal = equal;
-            this.greater = greater;
-        }
-
-        public Node lower;
-        public Node equal;
-        public Node greater;
-    }
-
-    class NodePair {
-        public NodePair(Node first, Node second) {
-            this.first = first;
-            this.second = second;
-        }
-
-        public Node first;
-        public Node second;
-    }
-
-    class Node {
+namespace Benchmark {
+    sealed class Node {
         public static Random random = new Random();
 
         int x;
@@ -48,28 +25,27 @@ namespace Benchmark
             }
         }
 
-        public static NodePair splitBinary(Node orig, int value) {
+        public static (Node first, Node second) splitBinary(Node orig, int value) {
             if (orig == null)
-                return new NodePair(null, null);
-
-            if (orig.x < value) {
-                NodePair splitPair = splitBinary(orig.right, value);
-                orig.right = splitPair.first;
-                return new NodePair(orig, splitPair.second);
+                return default;
+            else if (orig.x < value) {
+                var (first, second) = splitBinary(orig.right, value);
+                orig.right = first;
+                return (orig, second);
             } else {
-                NodePair splitPair = splitBinary(orig.left, value);
-                orig.left = splitPair.second;
-                return new NodePair(splitPair.first, orig);
+                var (first, second) = splitBinary(orig.left, value);
+                orig.left = second;
+                return (first, orig);
             }
         }
 
         public static Node merge(Node lower, Node equal, Node greater)
             => merge(merge(lower, equal), greater);
 
-        public static SplitResult split(Node orig, int value) {
-            NodePair lowerOther = splitBinary(orig, value);
-            NodePair equalGreater = splitBinary(lowerOther.second, value + 1);
-            return new SplitResult(lowerOther.first, equalGreater.first, equalGreater.second);
+        public static (Node lower, Node equal, Node greater) split(Node orig, int value) {
+            var lowerOther = splitBinary(orig, value);
+            var equalGreater = splitBinary(lowerOther.second, value + 1);
+            return (lowerOther.first, equalGreater.first, equalGreater.second);
         }
     }
 
@@ -77,17 +53,14 @@ namespace Benchmark
         Node mRoot;
 
         public bool hasValue(int x) {
-            SplitResult splited = Node.split(mRoot, x);
-            bool res = splited.equal != null;
-            mRoot = Node.merge(splited.lower, splited.equal, splited.greater);
-            return res;
+            var (lower, equal, greater) = Node.split(mRoot, x);
+            mRoot = Node.merge(lower, equal, greater);
+            return equal != null;
         }
 
         public void insert(int x) {
-            SplitResult splited = Node.split(mRoot, x);
-            if (splited.equal == null)
-                splited.equal = new Node(x);
-            mRoot = Node.merge(splited.lower, splited.equal, splited.greater);
+            var (lower, equal, greater) = Node.split(mRoot, x);
+            mRoot = Node.merge(lower, equal ?? new Node(x), greater);
         }
 
         public void erase(int x) {

--- a/c#/Program.cs
+++ b/c#/Program.cs
@@ -27,14 +27,12 @@ namespace Benchmark
     class Node {
         public static Random random = new Random();
 
-        public Node(int x) {
-            this.x = x;
-        }
-
         int x;
         int y = random.Next();
         Node left, right;
 
+        public Node(int x)
+            => this.x = x;
 
         public static Node merge(Node lower, Node greater) {
             if (lower == null)

--- a/c#/Program.cs
+++ b/c#/Program.cs
@@ -37,11 +37,9 @@ namespace Benchmark
         public static Node merge(Node lower, Node greater) {
             if (lower == null)
                 return greater;
-
-            if (greater == null)
+            else if (greater == null)
                 return lower;
-
-            if (lower.y < greater.y) {
+            else if (lower.y < greater.y) {
                 lower.right = merge(lower.right, greater);
                 return lower;
             } else {

--- a/c#/Program.cs
+++ b/c#/Program.cs
@@ -65,9 +65,8 @@ namespace Benchmark
             }
         }
 
-        public static Node merge(Node lower, Node equal, Node greater) {
-            return merge(merge(lower, equal), greater);
-        }
+        public static Node merge(Node lower, Node equal, Node greater)
+            => merge(merge(lower, equal), greater);
 
         public static SplitResult split(Node orig, int value) {
             NodePair lowerOther = splitBinary(orig, value);

--- a/c#/Program.cs
+++ b/c#/Program.cs
@@ -121,7 +121,7 @@ namespace Benchmark
                         res++;
                 }
             }
-            System.Console.WriteLine(res);
+            Console.WriteLine(res);
         }
     }
 }

--- a/c#/Program.cs
+++ b/c#/Program.cs
@@ -103,12 +103,12 @@ namespace Benchmark
     {
         static void Main(string[] args)
         {
-            Tree tree = new Tree();
-            int cur = 5;
-            int res = 0;
+            var tree = new Tree();
+            var cur = 5;
+            var res = 0;
 
-            for (int i = 1; i < 1000000; i++) {
-                int a = i % 3;
+            for (var i = 1; i < 1000000; i++) {
+                var a = i % 3;
                 cur = (cur * 57 + 43) % 10007;
                 if (a == 0) {
                     tree.insert(cur);

--- a/c#/Program.cs
+++ b/c#/Program.cs
@@ -99,10 +99,8 @@ namespace Benchmark
         }
     }
 
-    class Program
-    {
-        static void Main(string[] args)
-        {
+    class Program {
+        static void Main() {
             var tree = new Tree();
             var cur = 5;
             var res = 0;

--- a/c#/Program.cs
+++ b/c#/Program.cs
@@ -33,8 +33,8 @@ namespace Benchmark
 
         int x;
         int y = random.Next();
-        Node left = null;
-        Node right = null;
+        Node left, right;
+
 
         public static Node merge(Node lower, Node greater) {
             if (lower == null)
@@ -78,7 +78,9 @@ namespace Benchmark
         }
     }
 
-    class Tree {
+    sealed class Tree {
+        Node mRoot;
+
         public bool hasValue(int x) {
             SplitResult splited = Node.split(mRoot, x);
             bool res = splited.equal != null;
@@ -97,8 +99,6 @@ namespace Benchmark
             SplitResult splited = Node.split(mRoot, x);
             mRoot = Node.merge(splited.lower, splited.greater);
         }
-
-        private Node mRoot = null;
     }
 
     class Program

--- a/c#/Program.cs
+++ b/c#/Program.cs
@@ -69,7 +69,7 @@ namespace Benchmark {
         }
     }
 
-    class Program {
+    static class Program {
         static void Main() {
             var tree = new Tree();
             var cur = 5;

--- a/c#/Program.cs
+++ b/c#/Program.cs
@@ -94,7 +94,7 @@ namespace Benchmark
         }
 
         public void erase(int x) {
-            SplitResult splited = Node.split(mRoot, x);
+            var splited = Node.split(mRoot, x);
             mRoot = Node.merge(splited.lower, splited.greater);
         }
     }

--- a/c#/Program.cs
+++ b/c#/Program.cs
@@ -117,8 +117,7 @@ namespace Benchmark
                 } else if (a == 1) {
                     tree.erase(cur);
                 } else if (a == 2) {
-                    bool hasVal = tree.hasValue(cur);
-                    if (hasVal)
+                    if (tree.hasValue(cur))
                         res++;
                 }
             }

--- a/c#/README.md
+++ b/c#/README.md
@@ -1,6 +1,6 @@
 # C#
 
-Author: Nate Woolls (@nwoolls)
+Author: Nate Woolls (@nwoolls), Eamon Nerbonne @EamonNerbonne
 
 ## Compile
 
@@ -11,5 +11,5 @@ dotnet build -c release
 ## Execute
 
 ```
-dotnet bin/release/netcoreapp2.1/Benchmark.dll
+dotnet bin/release/netcoreapp2.0/Benchmark.dll
 ```


### PR DESCRIPTION
Primarily: replace behavior-less wrapper objects with tuples, use var (infer types).

Because tuples are value types, not heap types, this will reduce allocation somewhat.  On my machine, the runtime reduces from 582ms to 571ms (best of several runs) - but that's with startup time; and the benchmark is so small I think you're primarily measuring that.

I retained the default random number generator - but usage of a non-deterministic seed means reproducibility isn't ideal (even if the chances of significant deviation are slim to none).