### PR TITLE
Go  add sync pool

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -1,18 +1,29 @@
 # Go
 
-Authors: Patrick Burris (@jumballaya), Ilya Tocar (@TocarIP), @madarivi
+Authors: Patrick Burris (@jumballaya), Ilya Tocar (@TocarIP), @madarivi, @yml
 
 Translated from JavaScript version by: Vlad Frolov (@frol)
 
 ## Compile
 
 ```
-go build
-strip -s ./go
+go build -o treap main-raw.go
+```
+
+or
+
+```
+go build -o treap main-with-sync-pool.go
+```
+
+## Strip
+
+```
+strip -s ./treap
 ```
 
 ## Execute
 
 ```
-./go
+./treap
 ```

--- a/go/main-raw.go
+++ b/go/main-raw.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+type Node struct {
+	X        int
+	Y        int
+	Left     *Node
+	Right    *Node
+}
+
+func NewNode(v int) *Node {
+	y := rand.Int()
+	return &Node{
+		X:        v,
+		Y:        y,
+	}
+}
+
+type Tree struct {
+	Root *Node
+}
+
+func (t *Tree) HasValue(v int) bool {
+	splitted := split(t.Root, v)
+	res := splitted.Equal != nil
+	t.Root = merge3(splitted.Lower, splitted.Equal, splitted.Greater)
+	return res
+}
+
+func (t *Tree) Insert(v int) error {
+	splitted := split(t.Root, v)
+	if splitted.Equal == nil {
+		splitted.Equal = NewNode(v)
+	}
+	t.Root = merge3(splitted.Lower, splitted.Equal, splitted.Greater)
+	return nil
+}
+
+func (t *Tree) Erase(v int) error {
+	splitted := split(t.Root, v)
+	t.Root = merge(splitted.Lower, splitted.Greater)
+	return nil
+}
+
+type SplitResult struct {
+	Lower   *Node
+	Equal   *Node
+	Greater *Node
+}
+
+func merge(lower, greater *Node) *Node {
+	if lower == nil {
+		return greater
+	}
+
+	if greater == nil {
+		return lower
+	}
+
+	if lower.Y < greater.Y {
+		right := merge(lower.Right, greater)
+		lower.Right = right
+		return lower
+	}
+	left := merge(lower, greater.Left)
+	greater.Left = left
+	return greater
+}
+
+func merge3(lower, equal, greater *Node) *Node {
+	return merge(merge(lower, equal), greater)
+}
+
+func splitBinary(original *Node, value int) (*Node, *Node) {
+	if original == nil {
+		return nil, nil
+	}
+
+	if original.X < value {
+		splitPair0, splitPair1 := splitBinary(original.Right, value)
+		original.Right = splitPair0
+		return original, splitPair1
+	}
+
+	splitPair0, splitPair1 := splitBinary(original.Left, value)
+	original.Left = splitPair1
+	return splitPair0, original
+}
+
+func split(original *Node, value int) SplitResult {
+	lower, equalGreater := splitBinary(original, value)
+	equal, greater := splitBinary(equalGreater, value+1)
+	return SplitResult{lower, equal, greater}
+}
+
+func main() {
+	t := &Tree{}
+
+	cur := 5
+	res := 0
+
+	for i := 1; i < 1000000; i++ {
+		a := i % 3
+		cur = (cur*57 + 43) % 10007
+		if a == 0 {
+			t.Insert(cur)
+		} else if a == 1 {
+			t.Erase(cur)
+		} else if a == 2 {
+			has := t.HasValue(cur)
+			if has {
+				res += 1
+			}
+		}
+	}
+
+	fmt.Println(res)
+}

--- a/go/main-with-sync-pool.go
+++ b/go/main-with-sync-pool.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+)
+
+type Node struct {
+	X     int
+	Y     int
+	Left  *Node
+	Right *Node
+}
+
+func (n *Node) Set(v int) {
+	n.X = v
+	n.Y = rand.Int()
+}
+
+type Tree struct {
+	Root *Node
+	pool *sync.Pool
+}
+
+func NewTree() *Tree {
+
+	pool := sync.Pool{
+		New: func() interface{} { return &Node{} },
+	}
+	return &Tree{
+		Root: nil,
+		pool: &pool,
+	}
+}
+
+func (t *Tree) HasValue(v int) bool {
+	splitted := split(t.Root, v)
+	res := splitted.Equal != nil
+	t.Root = merge3(splitted.Lower, splitted.Equal, splitted.Greater)
+	return res
+}
+
+func (t *Tree) Insert(v int) error {
+	splitted := split(t.Root, v)
+	if splitted.Equal == nil {
+		node := t.pool.Get().(*Node)
+		node.Set(v)
+		splitted.Equal = node
+	}
+	t.Root = merge3(splitted.Lower, splitted.Equal, splitted.Greater)
+	return nil
+}
+
+func (t *Tree) Erase(v int) error {
+	splitted := split(t.Root, v)
+	if splitted.Equal != nil {
+		equal := splitted.Equal
+		t.pool.Put(equal)
+	}
+	t.Root = merge(splitted.Lower, splitted.Greater)
+	return nil
+}
+
+type SplitResult struct {
+	Lower   *Node
+	Equal   *Node
+	Greater *Node
+}
+
+func merge(lower, greater *Node) *Node {
+	if lower == nil {
+		return greater
+	}
+
+	if greater == nil {
+		return lower
+	}
+
+	if lower.Y < greater.Y {
+		right := merge(lower.Right, greater)
+		lower.Right = right
+		return lower
+	}
+	left := merge(lower, greater.Left)
+	greater.Left = left
+	return greater
+}
+
+func merge3(lower, equal, greater *Node) *Node {
+	return merge(merge(lower, equal), greater)
+}
+
+func splitBinary(original *Node, value int) (*Node, *Node) {
+	if original == nil {
+		return nil, nil
+	}
+
+	if original.X < value {
+		splitPair0, splitPair1 := splitBinary(original.Right, value)
+		original.Right = splitPair0
+		return original, splitPair1
+	}
+
+	splitPair0, splitPair1 := splitBinary(original.Left, value)
+	original.Left = splitPair1
+	return splitPair0, original
+}
+
+func split(original *Node, value int) SplitResult {
+	lower, equalGreater := splitBinary(original, value)
+	equal, greater := splitBinary(equalGreater, value+1)
+	return SplitResult{lower, equal, greater}
+}
+
+func treap(n int) int {
+	t := NewTree()
+
+	cur := 5
+	res := 0
+
+	for i := 1; i < n; i++ {
+		a := i % 3
+		cur = (cur*57 + 43) % 10007
+		if a == 0 {
+			t.Insert(cur)
+		} else if a == 1 {
+			t.Erase(cur)
+		} else if a == 2 {
+			has := t.HasValue(cur)
+			if has {
+				res += 1
+			}
+		}
+	}
+	return res
+}
+func main() {
+	fmt.Println(treap(1000000))
+}

--- a/go/main.go
+++ b/go/main.go
@@ -43,9 +43,11 @@ func (t *Tree) HasValue(v int) bool {
 
 func (t *Tree) Insert(v int) error {
 	splitted := split(t.Root, v)
-	node := t.pool.Get().(*Node)
-	node.Set(v)
-	splitted.Equal = node
+	if splitted.Equal == nil {
+		node := t.pool.Get().(*Node)
+		node.Set(v)
+		splitted.Equal = node
+	}
 	t.Root = merge3(splitted.Lower, splitted.Equal, splitted.Greater)
 	return nil
 }


### PR DESCRIPTION
The goal of this optimisation is to avoid to creation of garbage to
reduce the memory footprint of the running program.

I adding a *sync.Pool field to the Tree and we `Get` / `Put` nodes from
it. The idea is to recycle nodes instead of throwing them away.

This branch

```
~/gopath/src/github.com/frol/completely-unscientific-benchmarks/go go__add_sync_pool
yml@kodi$ sudo ./cgmemtime/cgmemtime ./go
331665
Child user:    0.324 s
Child sys :    0.000 s
Child wall:    0.328 s
Child high-water RSS                    :       1548 KiB
Recursive and acc. high-water RSS+CACHE :        872 KiB
```

compare to master

```
~/gopath/src/github.com/frol/completely-unscientific-benchmarks/go master
yml@kodi$ go build . &&strip -s ./go
~/gopath/src/github.com/frol/completely-unscientific-benchmarks/go master
yml@kodi$ sudo ./cgmemtime/cgmemtime ./go
331665
Child user:    0.336 s
Child sys :    0.004 s
Child wall:    0.353 s
Child high-water RSS                    :       6344 KiB
Recursive and acc. high-water RSS+CACHE :       5732 KiB
```

Thank you for your consideration.