### PR TITLE
removed useless code (Oberon is garbage-collected)

### DIFF
--- a/oberon07/CompleteUnscientificBenchmark.obn
+++ b/oberon07/CompleteUnscientificBenchmark.obn
@@ -21,15 +21,6 @@ BEGIN
    node^.y := Rand.NextInt();
 END InitNode;
 
-PROCEDURE DeleteNode(node: NodePtr);
-BEGIN
-   IF node # NIL THEN
-      IF node^.left # NIL THEN DeleteNode(node^.left)
-      ELSIF node^.right # NIL THEN DeleteNode(node^.right)
-      END; (* IF *)
-   END; (* IF *)
-END DeleteNode;
-
 PROCEDURE Merge(lower, greater: NodePtr): NodePtr;
 VAR
    result: NodePtr;
@@ -96,7 +87,6 @@ VAR
 BEGIN
    Split3(t.root, lower, equal, greater, val);
    t.root := Merge(lower, greater);
-   DeleteNode(equal);
 END Erase;
 
 PROCEDURE HasValue(VAR t: Tree; val: INTEGER): INTEGER;


### PR DESCRIPTION
These are the changes for Oberon-07. There's little significant difference; I just removed `DeleteNode()` because there's no need for that in a garbage-collected language. (In fact, it doesn't actually do anything except chase down to `NIL`, then... nothing. This was due to copying from Modula-2, which had a `DEALLOCATE()` at the end of that chain.)