### PR TITLE
Add compiling with Cython in Python solution

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -13,3 +13,18 @@ python main.py
 ```
 pypy main.py
 ```
+
+## Cython
+
+Compile:
+
+```
+cython --embed main.py
+gcc -O3 -o main main.c $(pkg-config --cflags --libs python3)
+```
+
+Execute:
+
+```
+./main
+```

--- a/python/main.py
+++ b/python/main.py
@@ -13,11 +13,11 @@ class Node:
 
 def merge(lower, greater):
     if lower is None:
-    	return greater
-    
+        return greater
+
     if greater is None:
-    	return lower
-    
+        return lower
+
     if lower.y < greater.y:
         lower.right = merge(lower.right, greater)
         return lower
@@ -27,8 +27,8 @@ def merge(lower, greater):
 
 def splitBinary(orig, value):
     if orig is None:
-    	return (None, None)
-    
+        return (None, None)
+
     if orig.x < value:
         splitPair = splitBinary(orig.right, value)
         orig.right = splitPair[0]
@@ -68,13 +68,13 @@ class Tree:
         res = splited.equal is not None
         self.root = merge3(splited.lower, splited.equal, splited.greater)
         return res
-    
+
     def insert(self, x):
         splited = split(self.root, x)
         if splited.equal is None:
             splited.equal = Node(x)
         self.root = merge3(splited.lower, splited.equal, splited.greater)
-    
+
     def erase(self, x):
         splited = split(self.root, x)
         self.root = merge(splited.lower, splited.greater)


### PR DESCRIPTION
Simple compiling with Cython gets about 50% performance improvement in my Arch Linux box.

Environment:

```
$ uname -a
Linux zbox 4.19.11-arch1-1-ARCH #1 SMP PREEMPT Thu Dec 20 03:40:28 UTC 2018 x86_64 GNU/Linux
$ python --version
Python 3.7.1
$ cython --version
Cython version 0.29.2
$ gcc --version | head -1
gcc (GCC) 8.2.1 20181127
$ cat /proc/cpuinfo | grep "model name"
model name	: Intel(R) Core(TM) i5-2450M CPU @ 2.50GHz
model name	: Intel(R) Core(TM) i5-2450M CPU @ 2.50GHz
model name	: Intel(R) Core(TM) i5-2450M CPU @ 2.50GHz
model name	: Intel(R) Core(TM) i5-2450M CPU @ 2.50GHz
$ cat /proc/meminfo | grep MemTotal
MemTotal:        8142204 kB
```

Testing:

```
$ time python main.py 
331665

real	0m15.492s
user	0m15.451s
sys	0m0.014s
```

```
$ time ./main
331665

real	0m8.080s
user	0m8.063s
sys	0m0.007s
```