### PR TITLE
Update Haskell dependencies.

### DIFF
--- a/haskell/package.yaml
+++ b/haskell/package.yaml
@@ -8,7 +8,6 @@ dependencies:
 - base >=4 && <=5
 - primitive
 - mwc-random
-- strict-base-types
 executables:
   unscientific:
     main: Main.hs

--- a/haskell/stack.yaml
+++ b/haskell/stack.yaml
@@ -2,4 +2,4 @@ flags: {}
 packages:
 - '.'
 extra-deps: []
-resolver: lts-11.9
+resolver: lts-13.0


### PR DESCRIPTION
Switch to GHC 8.6.3 and remove unused dependency on strict-base-types.

I'm seeing a slight regression in times of around 0.01~0.02s but it is hard to say if it is "real".