### PR TITLE
Improve Crystal treap a little bit

### DIFF
--- a/crystal/main.cr
+++ b/crystal/main.cr
@@ -57,7 +57,7 @@ def split(orig, value)
   return SplitResult.new lower, equal, greater
 end
 
-class Tree
+struct Tree
   def initialize
     @root = nil
   end
@@ -100,7 +100,7 @@ def main
       res += tree.has_value(cur) ? 1 : 0
     end
   end
-  p res
+  puts res
 end
 
 main()


### PR DESCRIPTION
This makes the class `Tree` stack-allocated by making it a struct and it changes `p`  to `puts` which is the normal output method. `p` also inspects the value but that's useless on a number.