### PR TITLE
add unmanaged swift benchmark based on naive algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *.pyc
 nimcache
 rust/target
+.build

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "swift-benchmarks",
+    products: [
+        .executable(
+            name: "unmanaged",
+            targets: ["unmanaged"]),
+        .executable(
+            name: "naive",
+            targets:["naive"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "unmanaged",
+            dependencies: []),
+        .target(
+            name: "naive",
+            dependencies: []),
+    ]
+)

--- a/swift/README.md
+++ b/swift/README.md
@@ -4,13 +4,14 @@ Author: Vlad Frolov (@frol)
 
 ## Compile
 
+
 ```
-swiftc -O -Xcc -flto -whole-module-optimization -o main-swift main.swift
-strip -s main-swift
+swift build -c release -Xswiftc -O -Xcc -flto -Xswiftc -whole-module-optimization
 ```
 
 ## Execute
 
 ```
-./main-swift
+./.build/x86_64-apple-macosx/release/unmanaged
+./.build/x86_64-apple-macosx/release/naive
 ```

--- a/swift/Sources/naive/main.swift
+++ b/swift/Sources/naive/main.swift
@@ -1,20 +1,21 @@
 import Foundation
 
-class Node {
+
+fileprivate class Node {
     var x: Int
     var y: Int
     var left: Node? = nil
     var right: Node? = nil
-
+    
     init(x: Int) {
         self.x = x
-        self.y = Int(rand())
+        self.y = Int.random(in: 0...Int.max)
     }
 }
 
-func merge(lower: Node?, greater: Node?) -> Node?
+fileprivate func merge(lower: Node?, greater: Node?) -> Node?
 {
-    if let lower = lower, let greater = greater {   
+    if let lower = lower, let greater = greater {
         if lower.y < greater.y {
             lower.right = merge(lower: lower.right, greater: greater)
             return lower
@@ -23,14 +24,14 @@ func merge(lower: Node?, greater: Node?) -> Node?
             return greater
         }
     } else if lower == nil {
-    	return greater
+        return greater
     } else {
-    	return lower
+        return lower
     }
- 
+    
 }
 
-func splitBinary(orig: Node?, value: Int) -> (Node?, Node?)
+fileprivate func splitBinary(orig: Node?, value: Int) -> (Node?, Node?)
 {
     if let orig = orig {
         if orig.x < value {
@@ -43,20 +44,20 @@ func splitBinary(orig: Node?, value: Int) -> (Node?, Node?)
             return (splitPair.0, orig)
         }
     } else {
-    	return (nil, nil)
+        return (nil, nil)
     }
 }
 
-func merge(lower: Node?, equal: Node?, greater: Node?) -> Node?
+fileprivate func merge(lower: Node?, equal: Node?, greater: Node?) -> Node?
 {
     return merge(lower: merge(lower: lower, greater: equal), greater: greater)
 }
 
-class SplitResult {
+fileprivate class SplitResult {
     var lower: Node?
     var equal: Node?
     var greater: Node?
-
+    
     init(lower: Node?, equal: Node?, greater: Node?) {
         self.lower = lower
         self.equal = equal
@@ -64,14 +65,14 @@ class SplitResult {
     }
 }
 
-func split(orig: Node?, value: Int) -> SplitResult
+fileprivate func split(orig: Node?, value: Int) -> SplitResult
 {
     let (lower, equalGreater) = splitBinary(orig: orig, value: value)
     let (equal, greater) = splitBinary(orig: equalGreater, value: value + 1)
     return SplitResult(lower: lower, equal: equal, greater: greater)
 }
 
-class Tree
+fileprivate class Tree
 {
     public func hasValue(x: Int) -> Bool
     {
@@ -85,7 +86,7 @@ class Tree
     {
         let splited = split(orig: mRoot, value: x)
         if splited.equal == nil {
-        	splited.equal = Node(x: x)
+            splited.equal = Node(x: x)
         }
         mRoot = merge(lower: splited.lower, equal: splited.equal, greater: splited.greater)
     }
@@ -99,7 +100,8 @@ class Tree
     private var mRoot: Node? = nil
 }
 
-func main() 
+
+func runNaive() -> Int
 {
     let tree = Tree()
     var cur = 5;
@@ -115,7 +117,9 @@ func main()
             default: break
         }
     }
-    print(res)
+    return res
 }
 
-main()
+
+print("Naive result \(runNaive())")
+

--- a/swift/Sources/unmanaged/main.swift
+++ b/swift/Sources/unmanaged/main.swift
@@ -1,0 +1,157 @@
+
+import Foundation
+
+
+fileprivate class Node {
+    var x: Int
+    var y: Int
+    var left: Unmanaged<Node>? = nil
+    var right: Unmanaged<Node>? = nil
+    
+    init(x: Int) {
+        self.x = x
+        self.y = Int.random(in: 0...Int.max)
+    }
+}
+
+fileprivate class Tree
+{
+    var root: Unmanaged<Node>? = nil
+}
+
+
+fileprivate func merge(lower: Unmanaged<Node>?, greater: Unmanaged<Node>?) -> Unmanaged<Node>?
+{
+    if let lower = lower, let greater = greater {
+        return lower._withUnsafeGuaranteedRef { lowerRef in
+            return greater._withUnsafeGuaranteedRef { greaterRef in
+                if lowerRef.y < greaterRef.y {
+                    lowerRef.right = merge(lower: lowerRef.right, greater: greater)
+                    return lower
+                } else {
+                    greaterRef.left = merge(lower: lower, greater: greaterRef.left)
+                    return greater
+                }
+            }
+        }
+    } else if lower == nil {
+        return greater
+    } else {
+        return lower
+    }
+    
+}
+
+fileprivate func splitBinary(orig: Unmanaged<Node>?, value: Int) -> (Unmanaged<Node>?, Unmanaged<Node>?)
+{
+    if let orig = orig {
+        return orig._withUnsafeGuaranteedRef {
+            if $0.x < value {
+                let splitPair = splitBinary(orig: $0.right, value: value)
+                $0.right = splitPair.0
+                return (orig, splitPair.1)
+            } else {
+                let splitPair = splitBinary(orig: $0.left, value: value)
+                $0.left = splitPair.1
+                return (splitPair.0, orig)
+            }
+        }
+
+    } else {
+        return (nil, nil)
+    }
+}
+
+fileprivate func merge(lower: Unmanaged<Node>?, equal: Unmanaged<Node>?, greater: Unmanaged<Node>?) -> Unmanaged<Node>?
+{
+    return merge(lower: merge(lower: lower, greater: equal), greater: greater)
+}
+
+fileprivate class SplitResult {
+    var lower: Unmanaged<Node>?
+    var equal: Unmanaged<Node>?
+    var greater: Unmanaged<Node>?
+    
+    init(lower: Unmanaged<Node>?, equal: Unmanaged<Node>?, greater: Unmanaged<Node>?) {
+        self.lower = lower
+        self.equal = equal
+        self.greater = greater
+    }
+}
+
+fileprivate func split(orig: Unmanaged<Node>?, value: Int) -> SplitResult
+{
+    let (lower, equalGreater) = splitBinary(orig: orig, value: value)
+    let (equal, greater) = splitBinary(orig: equalGreater, value: value + 1)
+    return SplitResult(lower: lower, equal: equal, greater: greater)
+}
+
+fileprivate func hasValue(_ tree: Unmanaged<Tree>, x: Int) -> Bool {
+    return tree._withUnsafeGuaranteedRef {
+        let splited = split(orig: $0.root, value: x)
+        let res = splited.equal != nil
+        $0.root = merge(lower: splited.lower, equal: splited.equal, greater: splited.greater)
+        return res
+    }
+}
+
+fileprivate func insert(_ tree: Unmanaged<Tree>, x: Int)
+{
+    // 1. split into greater, equal, lower trees
+    // 2. if there is no equal tree, create it,
+    // 3. merge into lower, equal, greater
+    tree._withUnsafeGuaranteedRef {
+        let splited = split(orig: $0.root, value: x)
+        if splited.equal == nil {
+            splited.equal = Unmanaged.passRetained(Node(x: x))
+        }
+        $0.root = merge(lower: splited.lower, equal: splited.equal, greater: splited.greater)
+    }
+}
+
+fileprivate func erase(_ tree: Unmanaged<Tree>, x: Int)
+{
+    // 1. split into greater, equal, lower trees
+    // 2. merge greater and lower trees
+    // 3. equal is left out.
+    tree._withUnsafeGuaranteedRef {
+        let splited = split(orig: $0.root, value: x)
+        $0.root = merge(lower: splited.lower, greater: splited.greater)
+        if splited.equal != nil {
+            splited.equal!.release()
+        }
+    }
+}
+
+fileprivate func cleanup(_ node: Unmanaged<Node>?) {
+    if let node = node {
+        node._withUnsafeGuaranteedRef {
+            cleanup($0.left)
+            cleanup($0.right)
+        }
+        node.release()
+    }
+}
+
+func runUnmanaged() -> Int {
+    let tree = Tree()
+    var cur = 5;
+    var res = 0
+    
+    let Ref = Unmanaged.passUnretained(tree)
+    
+    for i in 1..<1000000 {
+        let a = i % 3
+        cur = (cur * 57 + 43) % 10007
+        switch a {
+        case 0: insert(Ref, x: cur)
+        case 1: erase(Ref, x: cur)
+        case 2: if hasValue(Ref, x: cur) { res += 1 }
+        default: break
+        }
+    }
+    cleanup(tree.root)
+    return res
+}
+
+print("Unmanaged result \(runUnmanaged())")


### PR DESCRIPTION
This also adds a Package.swift so that you can build multiple benchmarks at once using `swift build` and updates the random function so that it can be built on both Linux and macOS.

I see about a 3.5x speedup on macOS using unmanaged vs managed.  It's possible this could be further tuned - using loops instead of recursion and other tricks to squeeze out more performance but I think just turning off arc results in a much larger performance increase than other strategies would.