### PR TITLE
Change gc for nim's fast implementation to recommended arc gc

### DIFF
--- a/nim/Makefile
+++ b/nim/Makefile
@@ -12,10 +12,10 @@ all: $(ALL_BINARIES)
 	nim compile -d:release --passC:-flto --passL:-s --out:$@ $<
 
 %-arc_gc: %.nim
-	nim compile -d:release --passC:-flto --passL:-s --gc:arc --out:$@ $<
+	nim compile -d:danger --passC:-flto --passL:-s --gc:arc --out:$@ $<
 
 %-no_gc: %.nim
-	nim compile -d:release --passC:-flto --passL:-s --gc:none --out:$@ $<
+	nim compile -d:danger --passC:-flto --passL:-s --gc:none --out:$@ $<
 
 RUN_ALL_BINARIES = $(ALL_BINARIES:main_%=run-%)
 

--- a/nim/Makefile
+++ b/nim/Makefile
@@ -1,7 +1,7 @@
 SRC_FILES = $(wildcard *.nim)
 TARGETS = $(SRC_FILES:main_%.nim=%)
 
-ALL_BINARIES = $(TARGETS:%=main_%) main_fast-arc_gc main_manual-no_gc
+ALL_BINARIES = $(TARGETS:%=main_%) main_fast-mark_and_sweep main_manual-no_gc
 
 .PHONY: all
 all: $(ALL_BINARIES)
@@ -11,8 +11,8 @@ all: $(ALL_BINARIES)
 %: %.nim
 	nim compile -d:release --passC:-flto --passL:-s --out:$@ $<
 
-%-arc_gc: %.nim
-	nim compile -d:danger --passC:-flto --passL:-s --gc:arc --out:$@ $<
+%-mark_and_sweep: %.nim
+	nim compile -d:danger --passC:-flto --passL:-s --gc:markAndSweep --out:$@ $<
 
 %-no_gc: %.nim
 	nim compile -d:danger --passC:-flto --passL:-s --gc:none --out:$@ $<

--- a/nim/Makefile
+++ b/nim/Makefile
@@ -1,7 +1,7 @@
 SRC_FILES = $(wildcard *.nim)
 TARGETS = $(SRC_FILES:main_%.nim=%)
 
-ALL_BINARIES = $(TARGETS:%=main_%) main_fast-mark_and_sweep main_manual-no_gc
+ALL_BINARIES = $(TARGETS:%=main_%) main_fast-arc_gc main_manual-no_gc
 
 .PHONY: all
 all: $(ALL_BINARIES)
@@ -11,8 +11,8 @@ all: $(ALL_BINARIES)
 %: %.nim
 	nim compile -d:release --passC:-flto --passL:-s --out:$@ $<
 
-%-mark_and_sweep: %.nim
-	nim compile -d:release --passC:-flto --passL:-s --gc:markAndSweep --out:$@ $<
+%-arc_gc: %.nim
+	nim compile -d:release --passC:-flto --passL:-s --gc:arc --out:$@ $<
 
 %-no_gc: %.nim
 	nim compile -d:release --passC:-flto --passL:-s --gc:none --out:$@ $<

--- a/nim/README.md
+++ b/nim/README.md
@@ -8,16 +8,16 @@ Author: Vlad Frolov (@frol)
 nim compile -d:release --passC:-flto --passL:-s --out:main-nim main.nim
 ```
 
-For maximum performance ([memory is the trade-off](https://github.com/frol/completely-unscientific-benchmarks/pull/1), currently a bug in Nim 0.18.0, fixed in devel):
+For a faster version that still uses the GC and returns a compound type:
 
 ```
-nim compile -d:release --passC:-flto --passL:-s --gc:markAndSweep --out:main-nim main.nim
+nim compile -d:release --passC:-flto --passL:-s --gc:arc --out:main-nim main.nim
 ```
 
-For a faster version that still uses the GC, but breaks the pattern of returning a compound type (like the C++ raw-pointer version):
+For an even faster version that still uses the GC, but breaks the pattern of returning a compound type (like the C++ raw-pointer version):
 
 ```
-nim compile -d:release --passC:-flto --passL:-s --gc:markAndSweep --out:main-nim main_fast.nim
+nim compile -d:release --passC:-flto --passL:-s --gc:arc --out:main-nim main_fast.nim
 ```
 
 For a version using manual memory allocation (so much less memory used):

--- a/nim/README.md
+++ b/nim/README.md
@@ -5,19 +5,19 @@ Author: Vlad Frolov (@frol)
 ## Compile
 
 ```
-nim compile -d:release --passC:-flto --passL:-s --out:main-nim main.nim
+nim compile -d:release --passC:-flto --passL:-s --out:main-nim main_naive.nim
 ```
 
 For a faster version without runtime safety checks that still uses the GC and returns a compound type:
 
 ```
-nim compile -d:danger --passC:-flto --passL:-s --gc:arc --out:main-nim main.nim
+nim compile -d:danger --passC:-flto --passL:-s --gc:markAndSweep --out:main-nim main_naive.nim
 ```
 
 For an even faster version without runtime safety checks that still uses the GC, but breaks the pattern of returning a compound type (like the C++ raw-pointer version):
 
 ```
-nim compile -d:danger --passC:-flto --passL:-s --gc:arc --out:main-nim main_fast.nim
+nim compile -d:danger --passC:-flto --passL:-s --gc:markAndSweep --out:main-nim main_fast.nim
 ```
 
 For a version without runtime safety checks and using manual memory allocation (so much less memory used):

--- a/nim/README.md
+++ b/nim/README.md
@@ -8,22 +8,22 @@ Author: Vlad Frolov (@frol)
 nim compile -d:release --passC:-flto --passL:-s --out:main-nim main.nim
 ```
 
-For a faster version that still uses the GC and returns a compound type:
+For a faster version without runtime safety checks that still uses the GC and returns a compound type:
 
 ```
-nim compile -d:release --passC:-flto --passL:-s --gc:arc --out:main-nim main.nim
+nim compile -d:danger --passC:-flto --passL:-s --gc:arc --out:main-nim main.nim
 ```
 
-For an even faster version that still uses the GC, but breaks the pattern of returning a compound type (like the C++ raw-pointer version):
+For an even faster version without runtime safety checks that still uses the GC, but breaks the pattern of returning a compound type (like the C++ raw-pointer version):
 
 ```
-nim compile -d:release --passC:-flto --passL:-s --gc:arc --out:main-nim main_fast.nim
+nim compile -d:danger --passC:-flto --passL:-s --gc:arc --out:main-nim main_fast.nim
 ```
 
-For a version using manual memory allocation (so much less memory used):
+For a version without runtime safety checks and using manual memory allocation (so much less memory used):
 
 ```
-nim compile -d:release --passC:-flto --passL:-s --gc:none --out:main-nim main_manual.nim
+nim compile -d:danger --passC:-flto --passL:-s --gc:none --out:main-nim main_manual.nim
 ```
 
 NOTE: To compile statically, add `--passL:-static` flag.


### PR DESCRIPTION
While markAndSweep is mostly better than the default gc in nim, the new "arc" gc is even more performant and results in a lot less memory usage overall. In order to be consistent with new upstream development, the "fast" nim implementation should use arc. More details available at https://nim-lang.org/docs/gc.html

See https://youtu.be/yA32Wxl59wo?t=830 for an example benchmark. Using arc instead of markAndSweep saves over 10 seconds and uses less memory!